### PR TITLE
Small fix in the worker with getting the default queue

### DIFF
--- a/app/code/community/Jowens/JobQueue/Model/Worker.php
+++ b/app/code/community/Jowens/JobQueue/Model/Worker.php
@@ -14,7 +14,7 @@ class Jowens_JobQueue_Model_Worker extends Mage_Core_Model_Abstract
 	public function __construct() {
 		list($hostname, $pid) = array(trim(`hostname`), getmypid());
         $this->workerName = "host::$hostname pid::$pid";
-        $this->queue = Mage::getStoreConfig('jobqueue/config/queue', self::DEFAULT_QUEUE);	
+        $this->queue = Mage::getStoreConfig('jobqueue/config/queue') :? self::DEFAULT_QUEUE;	
 	}
 
 	public function getQueue() {


### PR DESCRIPTION
I think you wanted to pass the default vallue to the Mage::getStoreConfig method. However (at least in 1.7) this is not possible and throws an exception.

If I am missing something or my assumption is wrong please correct me.
