### PR TITLE
Log exceptions using Mage::logException() instead of Mage::log()

### DIFF
--- a/app/code/community/Jowens/JobQueue/Model/Job/Abstract.php
+++ b/app/code/community/Jowens/JobQueue/Model/Job/Abstract.php
@@ -17,7 +17,7 @@ abstract class Jowens_JobQueue_Model_Job_Abstract extends Mage_Core_Model_Abstra
       $this->perform();
     } catch(Exception $e) {
       $this->enqueue($retryQueue);
-      Mage::log($e);
+      Mage::logException($e);
     }
   }
 

--- a/app/code/community/Jowens/JobQueue/Model/Worker.php
+++ b/app/code/community/Jowens/JobQueue/Model/Worker.php
@@ -75,7 +75,7 @@ class Jowens_JobQueue_Model_Worker extends Mage_Core_Model_Abstract
                 }
             }
         } catch (Exception $e) {
-            Mage::log($e);
+            Mage::logException($e);
         }
     }
 

--- a/app/code/community/Jowens/JobQueue/controllers/Adminhtml/QueueController.php
+++ b/app/code/community/Jowens/JobQueue/controllers/Adminhtml/QueueController.php
@@ -131,7 +131,7 @@ class Jowens_JobQueue_Adminhtml_QueueController extends Mage_Adminhtml_Controlle
                 $job->resubmit();
                 $success++;
             } catch (Exception $e) {
-                Mage::log($e);
+                Mage::logException($e);
                 $error++;
             }
         }
@@ -164,7 +164,7 @@ class Jowens_JobQueue_Adminhtml_QueueController extends Mage_Adminhtml_Controlle
                     $success++;
                 }
             } catch (Exception $e) {
-                Mage::log($e);
+                Mage::logException($e);
                 $error++;
             }
         }
@@ -193,7 +193,7 @@ class Jowens_JobQueue_Adminhtml_QueueController extends Mage_Adminhtml_Controlle
                 $job->delete();
                 $success++;
             } catch (Exception $e) {
-                Mage::log($e);
+                Mage::logException($e);
                 $error++;
             }
         }


### PR DESCRIPTION
We ran into issues in the past when logging exceptions using Mage::log instead of Mage::logException. Also it is more handy to log exceptions in the exception log.