### PR TITLE
Run mysql init statements from Magento configuration

### DIFF
--- a/app/code/community/Jowens/JobQueue/Model/Worker.php
+++ b/app/code/community/Jowens/JobQueue/Model/Worker.php
@@ -93,5 +93,9 @@ class Jowens_JobQueue_Model_Worker extends Mage_Core_Model_Abstract
             $dsn, 
             array('mysql_user' => $config->username, 'mysql_pass' => $config->password)
             );
+
+        if(!empty($config->initStatements)) {
+            DJJob::runQuery($config->initStatements);
+        }
     }
 }


### PR DESCRIPTION
We ran into encoding issues as Magento initializes the database connection to use utf-8 encoding (sql statement "set names utf8"). This is configurable in configuration node global/resources/default_setup/connection/initStatements (see app/etc/config.xml). When a job is queued, DJJob opens a new database connection which also also has to be initialized with utf8 encoding. Otherwise you run into errors when unserializing the handler object.