### PR TITLE
Fixing timezone gap when selecting scheduled jobs to run

### DIFF
--- a/app/code/community/Jowens/JobQueue/Model/Worker.php
+++ b/app/code/community/Jowens/JobQueue/Model/Worker.php
@@ -53,7 +53,7 @@ class Jowens_JobQueue_Model_Worker extends Mage_Core_Model_Abstract
             $collection->addFieldToFilter('queue', array('eq' => $this->getQueue()))
             ->addFieldToFilter('run_at', array(
                 array('null' => true),
-                array('lteq'=> date('Y-m-d H:i:s', Mage::app()->getLocale()->storeTimeStamp()))                 
+                array('lteq'=> date('Y-m-d H:i:s'))
                 ))
             ->addFieldToFilter(array('locked_at', 'locked_by'), array(
                 array('locked_at', 'null' => true),


### PR DESCRIPTION
Times are saved in UTC in the jobs table. So we must not filter the jobs to run by the store timestamp but in UTC.