### PR TITLE
Add setting for sort and limit

### DIFF
--- a/app/code/community/Jowens/JobQueue/Model/Worker.php
+++ b/app/code/community/Jowens/JobQueue/Model/Worker.php
@@ -65,8 +65,18 @@ class Jowens_JobQueue_Model_Worker extends Mage_Core_Model_Abstract
             ->addFieldToFilter('failed_at', array('null' => true))
             ->addFieldToFilter('attempts', array('lt' => (int)Mage::getStoreConfig('jobqueue/config/max_attempts')));
 
-            // randomly order to prevent lock contention among workers
-            $collection->getSelect()->order(new Zend_Db_Expr('RAND()'));
+            if (Mage::getStoreConfigFlag('jobqueue/config/sort_random')) {
+                // randomly order to prevent lock contention among workers
+                $collection->getSelect()->order(new Zend_Db_Expr('RAND()'));
+            } else {
+                $collection->setOrder('id','ASC');
+            }
+
+            $limit = Mage::getStoreConfig('jobqueue/config/limit_jobs');
+            if ($limit > 0) {
+                $collection->getSelect()->limit($limit);
+            }
+
             $collection->load();
 
             foreach($collection as $row) {

--- a/app/code/community/Jowens/JobQueue/etc/config.xml
+++ b/app/code/community/Jowens/JobQueue/etc/config.xml
@@ -88,6 +88,8 @@
                 <enabled>1</enabled>               
                 <cron_expr>*/5 * * * *</cron_expr>
                 <max_attempts>10</max_attempts>
+                <limit_jobs>1000</limit_jobs>
+                <sort_random>1</sort_random>
                 <queue>default</queue>
                 <log_level>0</log_level>
             </config>

--- a/app/code/community/Jowens/JobQueue/etc/system.xml
+++ b/app/code/community/Jowens/JobQueue/etc/system.xml
@@ -33,6 +33,20 @@
                             <sort_order>50</sort_order>                            
                             <show_in_default>1</show_in_default>
                         </max_attempts>
+                        <limit_jobs>
+                            <label>Limit Jobs</label>
+                            <frontend_type>text</frontend_type>
+                            <sort_order>51</sort_order>
+                            <show_in_default>1</show_in_default>
+                            <comment>Set to 0 to have no limit</comment>
+                        </limit_jobs>
+                        <sort_random>
+                            <label>Sort Jobs Randomly</label>
+                            <frontend_type>select</frontend_type>
+                            <source_model>adminhtml/system_config_source_yesno</source_model>
+                            <show_in_default>1</show_in_default>
+                            <sort_order>52</sort_order>
+                        </sort_random>
                         <queue>
                             <label>Queue</label>
                             <frontend_type>text</frontend_type>


### PR DESCRIPTION
It would be nice of you could set a limit of jobs to process at one time. Now we run in to the problem that many new jobs are added at the same time and we're hitting a memory limit when all these jobs need to be handle in one go.

We would also like to have the possibility to run the jobs in the first in first out order instead of random. 

I added two settings to manage this functionality.