### PR TITLE
Feature: use version 1.0.0 of the seatgeek/djjob module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "description": "JobQueue for Magento using DJJob",
     "require": {
       "php": ">=5.1",
-      "seatgeek/djjob": "dev-master"
+      "seatgeek/djjob": "1.0.0"
     },
     "authors": [
         {


### PR DESCRIPTION
The seatgeek/djjob was required as dev-master. This causes an error if you have your composer's 'minimal-stability' setting configured to 'stable'

The seatgeek/djjob module has a tagged release. We simply require this version and all is well.

https://github.com/seatgeek/djjob/releases